### PR TITLE
bugfix: if spinlock not success, it will grow 'retryTimes' of gorunti…

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -43,7 +43,7 @@ func NewRedisLock(client RedisClient, key string) (*RedisLock, error) {
 // TryLock attempt to lock, return true if the lock is successful, otherwise false
 func (rl *RedisLock) TryLock(ctx context.Context) (bool, error) {
 	succ, err := rl.Client.SetNX(ctx, rl.Key, rl.uuid, defaultExp).Result()
-	if err != nil {
+	if err != nil || !succ {
 		return false, err
 	}
 	c, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
bugfix: if spinlock not success, it will grow 'retryTimes' of goruntine by refresh function.
eg: if retryTimes is 10,  there will create 10 new grountines to refresh the lock life-duration. And also, the canclFuction will be REPLACED by SpinLockn, although it may be not success.